### PR TITLE
fix: change package name from @ng-valid/core to ng-valid for public n…

### DIFF
--- a/packages/ng-valid/package.json
+++ b/packages/ng-valid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ng-valid/core",
+  "name": "ng-valid",
   "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
…pm publishing

- Remove scoped package name to avoid private package fees
- Align with README.md installation instructions
- Enable public npm package publishing without paid plan

🤖 Generated with [Claude Code](https://claude.ai/code)