### PR TITLE
fix: change package name from @ng-valid/core to ng-valid for public n…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ packages/ng-valid/src/lib/contains/
 
 ### Implementation Notes
 - **ALWAYS use Pull Request workflow** for ANY changes (validators, docs, configs, etc.)
+- **ALWAYS create feature branch from latest main** - run `git checkout main && git pull origin main` first
 - **Create feature branch** for each change (e.g., `feat/validator-name`, `docs/readme-update`, `fix/bug-name`)
 - **Never commit directly to main** - all changes must go through PR review
 - Follow Angular v20+ best practices (standalone components, signals, etc.)
@@ -129,12 +130,13 @@ packages/ng-valid/src/lib/contains/
 - **Configuration**: `chore/description` (e.g., `chore/update-deps`, `chore/jest-config`)
 
 ### Required PR Process
-1. **Create feature branch**: `git checkout -b feat/feature-name`
-2. **Implement changes** with proper testing
-3. **Commit with conventional format**: `feat(scope): description`
-4. **Push branch**: `git push origin feat/feature-name`
-5. **Create Pull Request** with descriptive title and body
-6. **Wait for review** before merging to main
+1. **Start from latest main**: `git checkout main && git pull origin main`
+2. **Create feature branch**: `git checkout -b feat/feature-name`
+3. **Implement changes** with proper testing
+4. **Commit with conventional format**: `feat(scope): description`
+5. **Push branch**: `git push origin feat/feature-name`
+6. **Create Pull Request** with descriptive title and body
+7. **Wait for review** before merging to main
 
 ### PR Title Format
 Use conventional commit format:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5294,10 +5294,6 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
-    "node_modules/@ng-valid/core": {
-      "resolved": "packages/ng-valid",
-      "link": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -16254,6 +16250,10 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/ng-valid": {
+      "resolved": "packages/ng-valid",
+      "link": true
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -21619,7 +21619,6 @@
       }
     },
     "packages/ng-valid": {
-      "name": "@ng-valid/core",
       "version": "0.0.1",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/ng-valid/package.json
+++ b/packages/ng-valid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ng-valid/core",
+  "name": "ng-valid",
   "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
…pm publishing

- Remove scoped package name to avoid private package fees
- Align with README.md installation instructions
- Enable public npm package publishing without paid plan
- Update CLAUDE.md with proper branching strategy requiring latest main

🤖 Generated with [Claude Code](https://claude.ai/code)